### PR TITLE
docs: Fix a few typos

### DIFF
--- a/module/src/main/cpp/Dobby/source/InterceptRouting/InterceptRouting.cpp
+++ b/module/src/main/cpp/Dobby/source/InterceptRouting/InterceptRouting.cpp
@@ -59,7 +59,7 @@ ARM - 8 bytes:
   [data_address]
 */
 
-// Active routing, will patch the origin insturctions, and forward to our custom routing.
+// Active routing, will patch the origin instructions, and forward to our custom routing.
 // Patch the address with branch instr
 void InterceptRouting::Active() {
   void *patch_address = NULL;

--- a/module/src/main/cpp/Dobby/source/InterceptRouting/RoutingPlugin/FunctionWrapper/intercept_routing_handler.h
+++ b/module/src/main/cpp/Dobby/source/InterceptRouting/RoutingPlugin/FunctionWrapper/intercept_routing_handler.h
@@ -12,7 +12,7 @@ extern "C" {
 // Dispatch the routing befor running the origin function
 void prologue_routing_dispatch(RegisterContext *ctx, ClosureTrampolineEntry *entry);
 
-// Dispatch the routing before the function return . (as it's implementation by relpace `return address` in the stack
+// Dispatch the routing before the function return . (as it's implementation by replace `return address` in the stack
 // ,or LR register)
 void epilogue_routing_dispatch(RegisterContext *ctx, ClosureTrampolineEntry *entry);
 

--- a/module/src/main/cpp/Dobby/source/Interceptor.h
+++ b/module/src/main/cpp/Dobby/source/Interceptor.h
@@ -3,7 +3,7 @@
 
 #include "dobby_internal.h"
 
-// List utilty
+// List utility
 
 struct list_head {
   struct list_head *next;

--- a/module/src/main/cpp/Dobby/source/UserMode/MultiThreadSupport/ThreadSupport.h
+++ b/module/src/main/cpp/Dobby/source/UserMode/MultiThreadSupport/ThreadSupport.h
@@ -21,7 +21,7 @@ typedef struct _CallStack {
   std::vector<StackFrame *> stackframes;
 } CallStack;
 
-// ThreadSupport base on vm_core, support mutipl platforms.
+// ThreadSupport base on vm_core, support multiple platforms.
 class ThreadSupport {
 public:
   // Push stack frame


### PR DESCRIPTION
There are small typos in:
- module/src/main/cpp/Dobby/source/InterceptRouting/InterceptRouting.cpp
- module/src/main/cpp/Dobby/source/InterceptRouting/RoutingPlugin/FunctionWrapper/intercept_routing_handler.h
- module/src/main/cpp/Dobby/source/Interceptor.h
- module/src/main/cpp/Dobby/source/UserMode/MultiThreadSupport/ThreadSupport.h

Fixes:
- Should read `utility` rather than `utilty`.
- Should read `replace` rather than `relpace`.
- Should read `multiple` rather than `mutipl`.
- Should read `instructions` rather than `insturctions`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md